### PR TITLE
Enhance training with fine-tuning and add evaluation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,24 @@ python main.py
 ```
 
 ## Highlights
-- EfficientNetB3 with frozen base
+- EfficientNetB3 with frozen base and optional fine-tuning
+- L2 regularization and dropout to reduce overfitting
 - Mixed precision training
 - Augmented image generators
 - Automatic dataset sanity checks and class-weighted training
+- TensorBoard logs under `logs/`
 - Grad-CAM explainability
+
+After the first training phase the last 20 layers of EfficientNetB3 are unfrozen and
+the model trains a few extra epochs with a smaller learning rate. Training and
+validation metrics are written to `logs/<timestamp>/training_log.csv` so you can
+visualize them in TensorBoard.
+
+To evaluate a saved model on a separate test set, run:
+
+```bash
+python -m src.eval_model
+```
 
 ## Reproducibility
 Random seeds for NumPy, Python and TensorFlow are set via `src/utils.set_seeds` which is called inside `main.py`.

--- a/src/config.py
+++ b/src/config.py
@@ -23,3 +23,11 @@ for directory in [TRAIN_IMG_DIR, MODEL_DIR]:
 IMAGE_SIZE = (380, 380)
 BATCH_SIZE = 32
 EPOCHS = 50
+
+# Fine-tuning settings
+FINE_TUNE_EPOCHS = 10
+FINE_TUNE_LR = 1e-5
+
+# Test data (used by evaluation script)
+TEST_IMG_DIR = os.path.join(DATA_DIR, "test_images")
+TEST_CSV_PATH = os.path.join(DATA_DIR, "test.csv")

--- a/src/eval_model.py
+++ b/src/eval_model.py
@@ -1,0 +1,54 @@
+import os
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import confusion_matrix, classification_report, roc_curve, auc
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+from tensorflow.keras.models import load_model
+from src.config import IMAGE_SIZE, MODEL_SAVE_PATH, TEST_CSV_PATH, TEST_IMG_DIR
+
+
+def evaluate_model():
+    if not os.path.exists(MODEL_SAVE_PATH):
+        raise FileNotFoundError(f"Model file not found: {MODEL_SAVE_PATH}")
+
+    df = pd.read_csv(TEST_CSV_PATH)
+    df['filename'] = df['id_code'].astype(str) + '.png'
+
+    datagen = ImageDataGenerator(rescale=1./255)
+    test_gen = datagen.flow_from_dataframe(
+        dataframe=df,
+        directory=TEST_IMG_DIR,
+        x_col='filename',
+        y_col='diagnosis',
+        target_size=IMAGE_SIZE,
+        batch_size=32,
+        class_mode='categorical',
+        shuffle=False
+    )
+
+    model = load_model(MODEL_SAVE_PATH)
+    preds = model.predict(test_gen)
+    y_true = test_gen.classes
+    y_pred = np.argmax(preds, axis=1)
+
+    print("Confusion Matrix")
+    print(confusion_matrix(y_true, y_pred))
+    print(classification_report(y_true, y_pred))
+
+    # ROC curves for each class
+    y_true_ohe = np.eye(preds.shape[1])[y_true]
+    for i in range(preds.shape[1]):
+        fpr, tpr, _ = roc_curve(y_true_ohe[:, i], preds[:, i])
+        roc_auc = auc(fpr, tpr)
+        plt.plot(fpr, tpr, label=f"Class {i} (AUC={roc_auc:.2f})")
+    plt.plot([0, 1], [0, 1], 'k--')
+    plt.xlabel('False Positive Rate')
+    plt.ylabel('True Positive Rate')
+    plt.title('ROC Curves')
+    plt.legend(loc='lower right')
+    plt.show()
+
+
+if __name__ == "__main__":
+    evaluate_model()

--- a/src/model.py
+++ b/src/model.py
@@ -3,6 +3,7 @@
 
 from tensorflow.keras.applications import EfficientNetB3
 from tensorflow.keras.layers import GlobalAveragePooling2D, Dense, Dropout, BatchNormalization
+from tensorflow.keras.regularizers import l2
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.metrics import AUC, Precision, Recall
@@ -15,10 +16,10 @@ def build_model(image_size, num_classes=5):
 
     x = base_model.output
     x = GlobalAveragePooling2D()(x)
-    x = Dense(128, activation='relu')(x)
+    x = Dense(128, activation='relu', kernel_regularizer=l2(1e-4))(x)
     x = Dropout(0.5)(x)
     x = BatchNormalization()(x)
-    output = Dense(num_classes, activation='softmax', dtype='float32')(x)
+    output = Dense(num_classes, activation='softmax', dtype='float32', kernel_regularizer=l2(1e-4))(x)
 
     model = Model(inputs=base_model.input, outputs=output)
     model.compile(

--- a/src/train.py
+++ b/src/train.py
@@ -2,18 +2,22 @@
 # train.py
 
 import os
-from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau
+from datetime import datetime
+from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau, TensorBoard, CSVLogger
 from src.model import build_model
-from src.config import IMAGE_SIZE, MODEL_SAVE_PATH, EPOCHS
+from src.config import IMAGE_SIZE, MODEL_SAVE_PATH, EPOCHS, FINE_TUNE_EPOCHS, FINE_TUNE_LR
 
 def train_model(train_gen, val_gen, class_weights=None):
     os.makedirs(os.path.dirname(MODEL_SAVE_PATH), exist_ok=True)
     model = build_model(IMAGE_SIZE)
 
+    log_dir = os.path.join("logs", datetime.now().strftime("%Y%m%d-%H%M%S"))
     callbacks = [
         EarlyStopping(patience=10, restore_best_weights=True),
         ModelCheckpoint(MODEL_SAVE_PATH, save_best_only=True),
-        ReduceLROnPlateau(monitor='val_loss', factor=0.2, patience=3, min_lr=1e-6)
+        ReduceLROnPlateau(monitor='val_loss', factor=0.2, patience=3, min_lr=1e-6),
+        TensorBoard(log_dir=log_dir),
+        CSVLogger(os.path.join(log_dir, "training_log.csv"))
     ]
 
     history = model.fit(
@@ -23,5 +27,27 @@ def train_model(train_gen, val_gen, class_weights=None):
         callbacks=callbacks,
         class_weight=class_weights,
     )
+
+    # Unfreeze some layers for fine-tuning
+    base_model = model.get_layer('efficientnetb3')
+    for layer in base_model.layers[-20:]:
+        layer.trainable = True
+    model.compile(
+        optimizer=Adam(learning_rate=FINE_TUNE_LR),
+        loss='categorical_crossentropy',
+        metrics=['accuracy', AUC(), Precision(), Recall()]
+    )
+
+    ft_history = model.fit(
+        train_gen,
+        validation_data=val_gen,
+        epochs=FINE_TUNE_EPOCHS,
+        callbacks=callbacks,
+        class_weight=class_weights,
+    )
+
+    # Combine histories
+    for k,v in ft_history.history.items():
+        history.history.setdefault(k, []).extend(v)
 
     return model, history


### PR DESCRIPTION
## Summary
- add fine-tuning settings to `config.py`
- apply L2 regularization and keep dropout in model definition
- log training to TensorBoard/CSV and perform two-phase training with unfreezing
- provide evaluation script for confusion matrix, F1 and ROC curves
- update README with new instructions

## Testing
- `python -m py_compile main.py src/*.py`
- `pip install -r requirements.txt` *(fails: No matching distribution found for tensorflow==2.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686bc8b215008328a039491a8517d5f7