### PR TITLE
Add Grad-CAM visualization utilities and report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,21 @@ To evaluate a saved model on a separate test set, run:
 python -m src.eval_model
 ```
 
+### Grad-CAM Visualization
+
+Generate Grad-CAM overlays for arbitrary images or entire folders:
+
+```bash
+python -m src.generate_gradcam path/to/image1.png path/to/folder --output gradcam_output
+```
+
+### Report Generation
+
+After running `eval_model` you can compile an HTML (or PDF) report combining the evaluation metrics and Grad-CAM samples:
+
+```bash
+python -m src.report_generator evaluation/ gradcam_output --html report.html --pdf report.pdf
+```
+
 ## Reproducibility
 Random seeds for NumPy, Python and TensorFlow are set via `src/utils.set_seeds` which is called inside `main.py`.

--- a/main.py
+++ b/main.py
@@ -3,12 +3,17 @@
 
 from src.data_loader import get_data_generators
 from src.train import train_model
-from src.evaluate import get_last_conv_layer_name, make_gradcam_heatmap, display_gradcam
+from src.evaluate import (
+    get_last_conv_layer_name,
+    make_gradcam_heatmap,
+    save_gradcam,
+)
 from src.config import MODEL_SAVE_PATH
 from src.utils import set_seeds
 import numpy as np
 from tensorflow.keras.preprocessing import image
 import datetime
+import os
 
 def main():
     set_seeds()
@@ -31,7 +36,8 @@ def main():
 
     last_conv = get_last_conv_layer_name(model)
     heatmap = make_gradcam_heatmap(img_array, model, last_conv)
-    display_gradcam(sample_img, heatmap)
+    os.makedirs("sample_gradcam", exist_ok=True)
+    save_gradcam(sample_img, heatmap, os.path.join("sample_gradcam", "sample_gradcam.png"))
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy==1.23.5
 matplotlib==3.7.2
 opencv-python==4.8.1.78
 scikit-learn==1.3.0
+jinja2==3.1.2
+weasyprint==59.0

--- a/src/eval_model.py
+++ b/src/eval_model.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -6,12 +7,14 @@ from sklearn.metrics import confusion_matrix, classification_report, roc_curve, 
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
 from tensorflow.keras.models import load_model
 from src.config import IMAGE_SIZE, MODEL_SAVE_PATH, TEST_CSV_PATH, TEST_IMG_DIR
+import itertools
 
 
-def evaluate_model():
+def evaluate_model(output_dir="evaluation"):
     if not os.path.exists(MODEL_SAVE_PATH):
         raise FileNotFoundError(f"Model file not found: {MODEL_SAVE_PATH}")
 
+    os.makedirs(output_dir, exist_ok=True)
     df = pd.read_csv(TEST_CSV_PATH)
     df['filename'] = df['id_code'].astype(str) + '.png'
 
@@ -32,22 +35,56 @@ def evaluate_model():
     y_true = test_gen.classes
     y_pred = np.argmax(preds, axis=1)
 
+    cm = confusion_matrix(y_true, y_pred)
+    report = classification_report(y_true, y_pred, output_dict=True)
+
     print("Confusion Matrix")
-    print(confusion_matrix(y_true, y_pred))
+    print(cm)
     print(classification_report(y_true, y_pred))
 
+    metrics = {
+        "confusion_matrix": cm.tolist(),
+        "classification_report": report,
+    }
+
+    with open(os.path.join(output_dir, "metrics.json"), "w") as f:
+        json.dump(metrics, f, indent=2)
+
+    # Confusion matrix plot
+    plt.figure(figsize=(6, 6))
+    plt.imshow(cm, interpolation="nearest", cmap=plt.cm.Blues)
+    plt.title("Confusion Matrix")
+    plt.colorbar()
+    tick_marks = np.arange(len(test_gen.class_indices))
+    plt.xticks(tick_marks, tick_marks)
+    plt.yticks(tick_marks, tick_marks)
+    thresh = cm.max() / 2.0
+    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
+        plt.text(j, i, cm[i, j], horizontalalignment="center",
+                 color="white" if cm[i, j] > thresh else "black")
+    plt.ylabel("True label")
+    plt.xlabel("Predicted label")
+    plt.tight_layout()
+    plt.savefig(os.path.join(output_dir, "confusion_matrix.png"))
+    plt.close()
+
     # ROC curves for each class
+    plt.figure()
     y_true_ohe = np.eye(preds.shape[1])[y_true]
     for i in range(preds.shape[1]):
         fpr, tpr, _ = roc_curve(y_true_ohe[:, i], preds[:, i])
         roc_auc = auc(fpr, tpr)
         plt.plot(fpr, tpr, label=f"Class {i} (AUC={roc_auc:.2f})")
-    plt.plot([0, 1], [0, 1], 'k--')
-    plt.xlabel('False Positive Rate')
-    plt.ylabel('True Positive Rate')
-    plt.title('ROC Curves')
-    plt.legend(loc='lower right')
-    plt.show()
+    plt.plot([0, 1], [0, 1], "k--")
+    plt.xlabel("False Positive Rate")
+    plt.ylabel("True Positive Rate")
+    plt.title("ROC Curves")
+    plt.legend(loc="lower right")
+    plt.tight_layout()
+    plt.savefig(os.path.join(output_dir, "roc_curves.png"))
+    plt.close()
+
+    return metrics
 
 
 if __name__ == "__main__":

--- a/src/generate_gradcam.py
+++ b/src/generate_gradcam.py
@@ -1,0 +1,58 @@
+import argparse
+import glob
+import os
+import numpy as np
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import image
+
+from src.config import MODEL_SAVE_PATH
+from src.evaluate import make_gradcam_heatmap, save_gradcam, get_last_conv_layer_name
+
+
+def collect_images(paths):
+    images = []
+    for p in paths:
+        if os.path.isdir(p):
+            images.extend(glob.glob(os.path.join(p, "*.png")))
+            images.extend(glob.glob(os.path.join(p, "*.jpg")))
+        else:
+            images.append(p)
+    return images
+
+
+def run(image_paths, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    model = load_model(MODEL_SAVE_PATH)
+    last_conv = get_last_conv_layer_name(model)
+
+    for img_path in image_paths:
+        img = image.load_img(img_path, target_size=model.input_shape[1:3])
+        img_array = image.img_to_array(img) / 255.0
+        img_array = np.expand_dims(img_array, axis=0)
+
+        preds = model.predict(img_array)
+        pred_label = np.argmax(preds[0])
+
+        heatmap = make_gradcam_heatmap(img_array, model, last_conv, pred_label)
+        base_name = os.path.splitext(os.path.basename(img_path))[0]
+        out_path = os.path.join(output_dir, f"{base_name}_gradcam.png")
+        save_gradcam(img_path, heatmap, out_path)
+        print(f"Saved Grad-CAM for {img_path} -> {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Grad-CAM images for arbitrary inputs")
+    parser.add_argument("images", nargs="+", help="Paths to images or directories")
+    parser.add_argument("--output", default="gradcam_output", help="Directory to save Grad-CAM images")
+    args = parser.parse_args()
+
+    img_list = collect_images(args.images)
+    if not img_list:
+        raise ValueError("No images found for Grad-CAM generation")
+
+    run(img_list, args.output)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -1,0 +1,121 @@
+"""Generate an HTML or PDF report summarizing evaluation results."""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from jinja2 import Template
+
+try:
+    from weasyprint import HTML  # optional PDF generation
+except ImportError:  # pragma: no cover - optional dependency
+    HTML = None
+
+
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Model Evaluation Report</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        h1 { text-align: center; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }
+        img { max-width: 100%; height: auto; margin-bottom: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Model Evaluation Report</h1>
+    <p>Generated: {{ timestamp }}</p>
+
+    <h2>Classification Report</h2>
+    <table>
+        <tr>
+            <th>Class</th><th>Precision</th><th>Recall</th><th>F1-Score</th><th>Support</th>
+        </tr>
+        {% for label, scores in report.items() if label not in ['accuracy', 'macro avg', 'weighted avg'] %}
+        <tr>
+            <td>{{ label }}</td>
+            <td>{{ '%.2f'|format(scores['precision']) }}</td>
+            <td>{{ '%.2f'|format(scores['recall']) }}</td>
+            <td>{{ '%.2f'|format(scores['f1-score']) }}</td>
+            <td>{{ scores['support'] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <h2>Confusion Matrix</h2>
+    <img src="{{ confusion_img }}" alt="Confusion Matrix">
+
+    <h2>ROC Curves</h2>
+    <img src="{{ roc_img }}" alt="ROC Curves">
+
+    <h2>Grad-CAM Samples</h2>
+    {% for img in gradcam_images %}
+        <img src="{{ img }}" alt="Grad-CAM">
+    {% endfor %}
+
+    {% if notes %}
+    <h2>Notes</h2>
+    <pre>{{ notes }}</pre>
+    {% endif %}
+</body>
+</html>
+"""
+
+
+def generate_report(metrics_path, gradcam_dir, output_html, notes_path=None, output_pdf=None):
+    with open(metrics_path) as f:
+        metrics = json.load(f)
+
+    report = metrics.get("classification_report", {})
+
+    confusion_img = os.path.join(os.path.dirname(metrics_path), "confusion_matrix.png")
+    roc_img = os.path.join(os.path.dirname(metrics_path), "roc_curves.png")
+    gradcam_images = []
+    if os.path.isdir(gradcam_dir):
+        for fname in sorted(os.listdir(gradcam_dir)):
+            if fname.lower().endswith((".png", ".jpg")):
+                gradcam_images.append(os.path.join(gradcam_dir, fname))
+
+    notes = None
+    if notes_path and os.path.isfile(notes_path):
+        with open(notes_path) as f:
+            notes = f.read()
+
+    template = Template(HTML_TEMPLATE)
+    html = template.render(
+        timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        report=report,
+        confusion_img=confusion_img,
+        roc_img=roc_img,
+        gradcam_images=gradcam_images,
+        notes=notes,
+    )
+
+    with open(output_html, "w") as f:
+        f.write(html)
+
+    if output_pdf:
+        if HTML is None:
+            raise RuntimeError("weasyprint is required for PDF output")
+        HTML(output_html).write_pdf(output_pdf)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate evaluation report")
+    parser.add_argument("metrics", help="Path to metrics.json produced by eval_model")
+    parser.add_argument("gradcam_dir", help="Directory containing Grad-CAM images")
+    parser.add_argument("--notes", help="Optional notes text file")
+    parser.add_argument("--html", default="report.html", help="Output HTML file")
+    parser.add_argument("--pdf", help="Optional PDF output file")
+    args = parser.parse_args()
+
+    generate_report(args.metrics, args.gradcam_dir, args.html, args.notes, args.pdf)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- enable saving Grad-CAM overlays and batch generation of Grad‑CAM images
- collect evaluation metrics and save confusion matrix/ROC curves
- add HTML/PDF report generator with Jinja2/WeasyPrint
- update training script to save a sample Grad-CAM image
- document new utilities in README
- add `jinja2` and `weasyprint` to requirements


