### PR TITLE
Add CLI, Dockerfile, and API server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -73,5 +73,27 @@ After running `eval_model` you can compile an HTML (or PDF) report combining the
 python -m src.report_generator evaluation/ gradcam_output --html report.html --pdf report.pdf
 ```
 
+## Command Line Interface
+Run training, evaluation or inference via a unified CLI:
+
+```bash
+python -m src.cli train --epochs 30
+python -m src.cli evaluate --output-dir evaluation
+python -m src.cli predict images/*.png --output predictions
+```
+
+
 ## Reproducibility
 Random seeds for NumPy, Python and TensorFlow are set via `src/utils.set_seeds` which is called inside `main.py`.
+
+## Docker
+Build the image and run the API server:
+
+```bash
+docker build -t dr-app .
+docker run -p 8000:8000 dr-app
+```
+
+## API Usage
+The server exposes a `/predict` endpoint. Submit an eye image via `POST` and
+receive the predicted grade along with a Grad-CAM overlay encoded as base64.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ opencv-python==4.8.1.78
 scikit-learn==1.3.0
 jinja2==3.1.2
 weasyprint==59.0
+fastapi==0.103.1
+uvicorn==0.23.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""DR Ophthalmology toolkit package."""

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+import numpy as np
+import cv2
+import base64
+from tensorflow.keras.models import load_model
+
+from src import config
+from src.evaluate import make_gradcam_heatmap, get_last_conv_layer_name
+
+app = FastAPI(title="DR Model API")
+
+
+@app.on_event("startup")
+def load_trained_model():
+    global model, last_conv
+    model = load_model(config.MODEL_SAVE_PATH)
+    last_conv = get_last_conv_layer_name(model)
+
+
+def apply_gradcam_overlay(img_rgb, heatmap, alpha=0.4):
+    heatmap = cv2.resize(heatmap, (img_rgb.shape[1], img_rgb.shape[0]))
+    heatmap = np.uint8(255 * heatmap)
+    heatmap = cv2.applyColorMap(heatmap, cv2.COLORMAP_JET)
+    overlay = cv2.addWeighted(img_rgb, 1 - alpha, heatmap, alpha, 0)
+    return overlay
+
+
+@app.post("/predict")
+async def predict(file: UploadFile = File(...)):
+    data = await file.read()
+    nparr = np.frombuffer(data, np.uint8)
+    img = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    img_resized = cv2.resize(img_rgb, config.IMAGE_SIZE)
+    img_array = img_resized.astype("float32") / 255.0
+    img_array = np.expand_dims(img_array, axis=0)
+    preds = model.predict(img_array)
+    grade = int(np.argmax(preds[0]))
+    heatmap = make_gradcam_heatmap(img_array, model, last_conv, grade)
+    overlay = apply_gradcam_overlay(img_rgb, heatmap)
+    _, buf = cv2.imencode(".png", cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR))
+    overlay_b64 = base64.b64encode(buf).decode()
+    return JSONResponse({"grade": grade, "overlay": overlay_b64})
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,101 @@
+import argparse
+import os
+import numpy as np
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import image
+
+from src import config
+from src.utils import set_seeds
+from src.data_loader import get_data_generators
+from src.train import train_model
+from src.eval_model import evaluate_model
+from src.evaluate import make_gradcam_heatmap, get_last_conv_layer_name, save_gradcam
+
+
+def override_config(data_dir=None, model_path=None, epochs=None, fine_tune_epochs=None, batch_size=None):
+    """Override values in config module based on CLI arguments."""
+    if data_dir:
+        config.DATA_DIR = data_dir
+        config.TRAIN_IMG_DIR = os.path.join(data_dir, "train_images")
+        config.TRAIN_CSV_PATH = os.path.join(data_dir, "train.csv")
+        config.TEST_IMG_DIR = os.path.join(data_dir, "test_images")
+        config.TEST_CSV_PATH = os.path.join(data_dir, "test.csv")
+    if model_path:
+        config.MODEL_SAVE_PATH = model_path
+    if epochs:
+        config.EPOCHS = epochs
+    if fine_tune_epochs:
+        config.FINE_TUNE_EPOCHS = fine_tune_epochs
+    if batch_size:
+        config.BATCH_SIZE = batch_size
+
+
+def cmd_train(args):
+    override_config(args.data_dir, args.model_path, args.epochs, args.ft_epochs, args.batch_size)
+    set_seeds()
+    train_gen, val_gen, class_weights = get_data_generators()
+    model, history = train_model(train_gen, val_gen, class_weights)
+    best_val_acc = max(history.history['val_accuracy'])
+    print(f"Training complete. Best val acc: {best_val_acc:.4f}")
+
+
+def cmd_evaluate(args):
+    override_config(args.data_dir, args.model_path)
+    metrics = evaluate_model(args.output_dir)
+    print("Evaluation metrics saved to", args.output_dir)
+
+
+def cmd_predict(args):
+    override_config(args.data_dir, args.model_path, batch_size=1)
+    model = load_model(config.MODEL_SAVE_PATH)
+    last_conv = get_last_conv_layer_name(model)
+    os.makedirs(args.output, exist_ok=True)
+    for img_path in args.images:
+        img = image.load_img(img_path, target_size=model.input_shape[1:3])
+        img_array = image.img_to_array(img) / 255.0
+        img_array = np.expand_dims(img_array, axis=0)
+        preds = model.predict(img_array)
+        grade = int(np.argmax(preds[0]))
+        heatmap = make_gradcam_heatmap(img_array, model, last_conv, grade)
+        base = os.path.splitext(os.path.basename(img_path))[0]
+        out_path = os.path.join(args.output, f"{base}_gradcam.png")
+        save_gradcam(img_path, heatmap, out_path)
+        print(f"{img_path} -> grade {grade}, gradcam saved to {out_path}")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="DR Ophthalmology CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_train = sub.add_parser("train", help="Train a model")
+    p_train.add_argument("--data-dir", help="Dataset directory")
+    p_train.add_argument("--model-path", default=config.MODEL_SAVE_PATH, help="Path to save model")
+    p_train.add_argument("--epochs", type=int, default=config.EPOCHS)
+    p_train.add_argument("--ft-epochs", type=int, default=config.FINE_TUNE_EPOCHS)
+    p_train.add_argument("--batch-size", type=int, default=config.BATCH_SIZE)
+    p_train.set_defaults(func=cmd_train)
+
+    p_eval = sub.add_parser("evaluate", help="Evaluate on test set")
+    p_eval.add_argument("--data-dir", help="Dataset directory")
+    p_eval.add_argument("--model-path", default=config.MODEL_SAVE_PATH)
+    p_eval.add_argument("--output-dir", default="evaluation")
+    p_eval.set_defaults(func=cmd_evaluate)
+
+    p_pred = sub.add_parser("predict", help="Predict images with Grad-CAM")
+    p_pred.add_argument("images", nargs='+', help="Image paths")
+    p_pred.add_argument("--data-dir", help="Dataset directory (optional)")
+    p_pred.add_argument("--model-path", default=config.MODEL_SAVE_PATH)
+    p_pred.add_argument("--output", default="predictions")
+    p_pred.set_defaults(func=cmd_predict)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement CLI interface for training, evaluation and prediction
- add FastAPI based API for serving the model
- provide Dockerfile for containerized setup
- document new CLI, Docker and API usage
- update requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870ececb9d083289af5dbf193043597