### PR TITLE
Allow skipping missing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ data/
 
 Place the dataset under `data/aptos2019-blindness-detection` so the paths in `src/config.py` work out of the box.
 The training script performs a sanity check at startup and will raise helpful
-errors if `train.csv` or any of the referenced images are missing.
+errors if `train.csv` or any of the referenced images are missing. Set
+`skip_missing=True` in `get_data_generators` to silently drop such rows instead
+of stopping with an error.
 
 ## Setup
 Create a virtual environment and install the dependencies:
@@ -54,7 +56,7 @@ python main.py
 - L2 regularisation and dropout to reduce overfitting
 - Mixed precision training
 - Augmented image generators
-- Automatic dataset sanity checks and class-weighted training
+- Automatic dataset sanity checks (optionally skipping missing files) and class-weighted training
 - TensorBoard logs under `logs/`
 - Grad-CAM explainability
 

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -21,8 +21,17 @@ def random_crop_and_color(img):
     return img
 
 
-def get_data_generators():
-    train_df = validate_dataset(TRAIN_CSV_PATH, TRAIN_IMG_DIR)
+def get_data_generators(skip_missing: bool = False):
+    """Return training/validation data generators and class weights.
+
+    When ``skip_missing`` is ``True``, any entries pointing to missing image
+    files are ignored instead of raising an error.
+    """
+    train_df = validate_dataset(
+        TRAIN_CSV_PATH,
+        TRAIN_IMG_DIR,
+        drop_missing=skip_missing,
+    )
     train_df['diagnosis'] = train_df['diagnosis'].astype(str)
 
     train_df, val_df = train_test_split(


### PR DESCRIPTION
## Summary
- optionally drop missing images from dataset validation
- make data loaders forward `skip_missing` flag
- document the behaviour in the README

## Testing
- `python -m py_compile src/utils.py src/data_loader.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68776448f87c8328a3c17d01d894603f